### PR TITLE
116: Adding color pallett to tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,12 @@ module.exports = {
   ],
   theme: {
     extend: {
+      colors: {
+        primary: '#143109',
+        secondary: '#AAAE7F',
+        tertiary: '#D0D6B3',
+        primaryg: '#F7F7F7',
+      },
       backgroundImage: {
         'gradient-radial': 'radial-gradient(var(--tw-gradient-stops))',
         'gradient-conic':


### PR DESCRIPTION
Verify that the tailwind config contains the following colors:
primary: '#143109',
secondary: '#AAAE7F',
tertiary: '#D0D6B3',
primaryBg: '#F7F7F7',

These colors are based from the prior GF theme and are needed before redesigning pages. 